### PR TITLE
perf(bundle): move to valita for runtime schema validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
+        "@badrap/valita": "^0.1.0",
         "babel-polyfill": "^6.26.0",
         "preact": "10.6.4",
         "preact-compat": "^3.19.0",
@@ -85,6 +86,10 @@
         "typescript": "^4.0.3",
         "workbox-build": "^5.1.4",
         "workbox-cli": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">= 6.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1877,6 +1882,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@badrap/valita": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@badrap/valita/-/valita-0.1.0.tgz",
+      "integrity": "sha512-pNPIxfLdx0nR7kFiZzZik0PIaUPGogwcnjr1MYKuqaqcXP/F8DW4e0NY+SICW8OUQsPgyO6W05H0u1tdA7l6WQ=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -27064,6 +27074,11 @@
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@badrap/valita": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@badrap/valita/-/valita-0.1.0.tgz",
+      "integrity": "sha512-pNPIxfLdx0nR7kFiZzZik0PIaUPGogwcnjr1MYKuqaqcXP/F8DW4e0NY+SICW8OUQsPgyO6W05H0u1tdA7l6WQ=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
+    "@badrap/valita": "^0.1.0",
     "babel-polyfill": "^6.26.0",
     "preact": "10.6.4",
     "preact-compat": "^3.19.0",

--- a/schemas/lastFm.ts
+++ b/schemas/lastFm.ts
@@ -1,4 +1,4 @@
-import { JSONSchemaType } from 'ajv'
+import * as v from '@badrap/valita'
 
 /*
  * LastFM Recenttracks JSON API
@@ -9,55 +9,57 @@ export type Artist = {
   '#text': string
 }
 
-export const artistSchema: JSONSchemaType<Artist> = {
-  type: 'object',
-  properties: {
-    '#text': { type: 'string' },
-  },
-  required: ['#text'],
-  additionalProperties: true,
-}
+export const artistSchema = v.object({
+  '#text': v.string(),
+  mbid: v.string(),
+})
 
 export type Track = {
   artist: Artist
   name: string
 }
 
-export const trackSchema: JSONSchemaType<Track> = {
-  type: 'object',
-  properties: {
-    artist: artistSchema,
-    name: { type: 'string' },
-  },
-  required: ['artist', 'name'],
-  additionalProperties: true,
-}
+export const trackSchema = v.object({
+  '@attr': v.record(v.string()).optional(),
+  album: v.record(v.string()),
+  artist: artistSchema,
+  date: v.record(v.string()).optional(),
+  image: v.array(v.record(v.string())),
+  mbid: v.string(),
+  name: v.string(),
+  streamable: v.string(),
+  url: v.string(),
+})
 
 export type Recenttracks = {
   track: Track[]
 }
 
-export const recenttracksSchema: JSONSchemaType<Recenttracks> = {
-  type: 'object',
-  properties: {
-    track: {
-      type: 'array',
-      items: trackSchema,
-    },
-  },
-  required: ['track'],
-  additionalProperties: true,
-}
+export const recenttracksSchema = v.object({
+  track: v.array(trackSchema),
+  '@attr': v.record(v.string()),
+})
+
+export const userRecenttracksSchema = v.object({
+  recenttracks: recenttracksSchema,
+})
 
 export type UserRecenttracks = {
   recenttracks: Recenttracks
 }
 
-export const userRecenttracksSchema: JSONSchemaType<UserRecenttracks> = {
-  type: 'object',
-  properties: {
-    recenttracks: recenttracksSchema,
-  },
-  required: ['recenttracks'],
-  additionalProperties: true,
+export const validate = <T>(schema: v.Type, data: unknown): T | undefined => {
+  try {
+    const result = schema.parse(data)
+    return result as T
+  } catch (err) {
+    console.warn(err instanceof Error ? err.message : err, {
+      err,
+      data,
+      schema,
+    })
+    if (err instanceof Error) {
+      throw err
+    }
+  }
 }

--- a/src/components/LastFm/index.tsx
+++ b/src/components/LastFm/index.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, FunctionComponent } from 'react'
-import Ajv from 'ajv'
-import { userRecenttracksSchema } from '../../../schemas/lastFm'
+import {
+  validate,
+  UserRecenttracks,
+  userRecenttracksSchema,
+} from '../../../schemas/lastFm'
 import { isPrerender } from '../../utils/prerender'
 import styled from 'styled-components'
 import useNetwork from '../../hooks/useNetwork'
@@ -69,10 +72,12 @@ const LastFm: FunctionComponent<LastFmProps> = ({ userName, apiKey }) => {
         })
         .then(data => {
           setIsPending(false)
-          const ajv = new Ajv()
-          const validate = ajv.compile(userRecenttracksSchema)
-          if (validate(data)) {
-            const { recenttracks } = data
+          const validData = validate<UserRecenttracks>(
+            userRecenttracksSchema,
+            data
+          )
+          if (validData) {
+            const { recenttracks } = validData
             setLastFmData({
               artistName: recenttracks.track[0].artist['#text'],
               songName: recenttracks.track[0].name,


### PR DESCRIPTION
This PR move to valita for runtime schema validation of lastFm.
This reduce the bundle size about ~40KB. Or ~40%.

